### PR TITLE
Windows: Bump bundled MinGW-based libs to v7.0.0 final (#3311)

### DIFF
--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -149,7 +149,7 @@ steps:
 - script: |
     cd ..
     cp llvm/bin/lld-link.exe installed/bin
-    curl -L -o mingw-w64-libs.7z https://github.com/ldc-developers/mingw-w64-libs/releases/download/v7.0.0-rc.1/mingw-w64-libs-v7.0.0-rc.1.7z 2>&1
+    curl -L -o mingw-w64-libs.7z https://github.com/ldc-developers/mingw-w64-libs/releases/download/v7.0.0/mingw-w64-libs-v7.0.0.7z 2>&1
     mkdir mingw-w64-libs
     cd mingw-w64-libs
     7z x ../mingw-w64-libs.7z > nul


### PR DESCRIPTION
They now support wide C wmain and wWinMain entry points.