### PR TITLE
Fix wrong assertion wrt. virtual function vtbl index (#3327)

### DIFF
--- a/gen/classes.cpp
+++ b/gen/classes.cpp
@@ -426,9 +426,10 @@ LLValue *DtoVirtualFunctionPointer(DValue *inst, FuncDeclaration *fdecl,
   assert(fdecl->isVirtual());
   assert(!fdecl->isFinalFunc());
   assert(inst->type->toBasetype()->ty == Tclass);
-  // 0 is always ClassInfo/Interface* unless it is a CPP interface
+  // slot 0 is always ClassInfo/Interface* unless it is a CPP class
   assert(fdecl->vtblIndex > 0 ||
-         (fdecl->vtblIndex == 0 && fdecl->linkage == LINKcpp));
+         (fdecl->vtblIndex == 0 &&
+          inst->type->toBasetype()->isTypeClass()->sym->isCPPclass()));
 
   // get instance
   LLValue *vthis = DtoRVal(inst);

--- a/tests/compilable/gh3324.d
+++ b/tests/compilable/gh3324.d
@@ -1,0 +1,8 @@
+// RUN: %ldc -c %s
+
+extern (C++) interface I
+{
+    extern (System) void func();
+}
+
+void foo(I i) { i.func(); }


### PR DESCRIPTION
Fixes #3324 by checking the aggregate linkage, not the function's, for special vtbl index 0.