### PR TITLE
WebAssembly: Switch from legacy linked-list ModuleInfo registry to __…

### DIFF
--- a/tests/baremetal/lit.local.cfg
+++ b/tests/baremetal/lit.local.cfg
@@ -4,13 +4,3 @@ import subprocess
 # * no ldc2.conf file is used (=> no implicit command-line args), and
 # * the empty object.d in ./inputs is imported (=> no TypeInfo, ModuleInfo, Object...).
 config.substitutions.append( ('%baremetal_args', '-conf= -I' + config.test_source_root + '/baremetal/inputs') )
-
-# Add "link_WebAssembly" feature if we can link wasm (-link-internally or wasm-ld in PATH).
-if config.ldc_with_lld:
-    config.available_features.add('link_WebAssembly')
-else:
-    try:
-        if (subprocess.call(["wasm-ld", "--version"]) == 0):
-            config.available_features.add('link_WebAssembly')
-    except OSError:
-        pass

--- a/tests/codegen/wasi.d
+++ b/tests/codegen/wasi.d
@@ -1,9 +1,15 @@
-// REQUIRES: atleast_llvm800, target_WebAssembly
+// REQUIRES: atleast_llvm900, target_WebAssembly, link_WebAssembly
 
-// RUN: %ldc -mtriple=wasm32-unknown-wasi -output-ll -of=%t.ll %s && FileCheck %s < %t.ll
+// emit textual IR *and* compile & link
+// RUN: %ldc -mtriple=wasm32-unknown-wasi -output-ll -output-o -of=%t.wasm %s
+// RUN: FileCheck %s < %t.ll
+
+
+// test predefined versions:
 
 version (WASI) {} else static assert(0);
 version (CRuntime_WASI) {} else static assert(0);
+
 
 // make sure TLS globals are emitted as regular __gshared globals:
 
@@ -11,3 +17,23 @@ version (CRuntime_WASI) {} else static assert(0);
 int definedGlobal = 123;
 // CHECK: @_D4wasi14declaredGlobali = external global i32
 extern int declaredGlobal;
+
+
+// make sure the ModuleInfo ref is emitted into the __minfo section:
+
+// CHECK: @_D4wasi11__moduleRefZ = linkonce_odr hidden global %object.ModuleInfo* {{.*}}, section "__minfo"
+// CHECK: @llvm.used = appending global [1 x i8*] [i8* {{.*}} @_D4wasi11__moduleRefZ
+
+
+// test the magic linker symbols via linkability of the following:
+
+extern(C) extern __gshared
+{
+    void* __start___minfo;
+    void* __stop___minfo;
+}
+
+extern(C) void _start()
+{
+    auto size = __stop___minfo - __start___minfo;
+}

--- a/tests/lit.site.cfg.in
+++ b/tests/lit.site.cfg.in
@@ -141,6 +141,16 @@ if canDoLTO:
 if config.ldc_with_lld:
     config.available_features.add('internal_lld')
 
+# Add "link_WebAssembly" feature if we can link wasm (-link-internally or wasm-ld in PATH).
+if config.ldc_with_lld:
+    config.available_features.add('link_WebAssembly')
+else:
+    try:
+        if (subprocess.call(["wasm-ld", "--version"]) == 0):
+            config.available_features.add('link_WebAssembly')
+    except OSError:
+        pass
+
 config.target_triple = '(unused)'
 
 # test_exec_root: The root path where tests should be run.


### PR DESCRIPTION
…minfo section (#3348)

As LLD 9+ supports the magic __{start,stop}___minfo linker symbols for
wasm targets.