### PR TITLE
Fix lit 12.0.1 installation regression (#3791)

### DIFF
--- a/.azure-pipelines/1-posix-setup.yml
+++ b/.azure-pipelines/1-posix-setup.yml
@@ -42,6 +42,7 @@ steps:
     fi
     # Install lit
     python3 --version
+    python3 -m pip install --user setuptools wheel
     python3 -m pip install --user lit
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
     # Download & extract host LDC

--- a/.azure-pipelines/windows.yml
+++ b/.azure-pipelines/windows.yml
@@ -38,6 +38,7 @@ steps:
     7z x ../ninja.zip > nul
     cd ..
     :: Install lit
+    python -m pip install --user setuptools wheel
     python -m pip install --user lit
     python -c "import lit.main; lit.main.main();" --version . | head -n 1
     :: Download & extract host LDC

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ commonSteps: &commonSteps
           fi
           # Install lit
           python3 --version
+          python3 -m pip install --user setuptools wheel
           python3 -m pip install --user lit
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
           # Download & extract host LDC

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -4,6 +4,7 @@
 common_steps_template: &COMMON_STEPS_TEMPLATE
   install_lit_script: |
     # Install lit
+    python3 -m pip install --user setuptools wheel
     python3 -m pip install --user lit
     python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
   clone_submodules_script: |

--- a/.github/workflows/supported_llvm_versions.yml
+++ b/.github/workflows/supported_llvm_versions.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Install lit
         run: |
           set -euxo pipefail
+          python3 -m pip install --user setuptools wheel
           python3 -m pip install --user lit
           python3 -c "import lit.main; lit.main.main();" --version . | head -n 1
       - name: "Linux: Install gdb"

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,7 @@ before_install:
 
 install:
   # Install lit
+  - python3 -m pip install --user setuptools wheel
   - python3 -m pip install --user lit
   - |
     set -o pipefail

--- a/shippable.yml
+++ b/shippable.yml
@@ -26,6 +26,7 @@ build:
         git-core cmake ninja-build \
         libcurl3 libcurl4-openssl-dev \
         curl gdb p7zip-full python3-pip tzdata unzip zip
+    - pip install --user setuptools wheel
     - pip install --user lit
     # Download & extract host LDC
     - curl -L -o ldc2.tar.xz https://github.com/ldc-developers/ldc/releases/download/v$HOST_LDC_VERSION/ldc2-$HOST_LDC_VERSION-linux-aarch64.tar.xz


### PR DESCRIPTION
For some Linux images at least, where the lit 12.0.1 upgrade came with
some nice `ModuleNotFoundError: No module named 'setuptools'` error
from one hour to the next.